### PR TITLE
Docker compose logstash stdin to kafka topic (using confluentinc images)

### DIFF
--- a/quickstart/logstash-to-kafka/docker-compose.yml
+++ b/quickstart/logstash-to-kafka/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.13.2
+    hostname: logstash
+    volumes:
+      - ./logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+    stdin_open: true 
+    tty: true
+    environment:
+      XPACK_MONITORING_ENABLED: "false"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    hostname: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - 2181:2181
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    hostname: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - 8080:8080
+    depends_on:
+      - kafka
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=PLAINTEXT://kafka:9092

--- a/quickstart/logstash-to-kafka/logstash.conf
+++ b/quickstart/logstash-to-kafka/logstash.conf
@@ -1,0 +1,12 @@
+input {
+  stdin {
+    id => "events_in"
+  }
+}
+
+output {
+  kafka {
+    topic_id => "events"
+    bootstrap_servers => "PLAINTEXT://kafka:9092"
+  }
+}


### PR DESCRIPTION
The pipeline starts with logstash waiting for input from stdin (use "docker attach" to link host stdin to logstash container stdin). Then input is sent to kafka topic "events" (verify with kafka-ui at https://localhost:8080).